### PR TITLE
Combined dependency updates (2022-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v3.5.2
+        uses: mikepenz/action-junit-report@v3.6.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -19,7 +19,7 @@
 		<httpclient-version>4.5.13</httpclient-version>
 		<spring-web-version>5.3.19</spring-web-version>
 		<jackson-version>2.13.4</jackson-version>
-		<jackson-databind-version>2.13.4.2</jackson-databind-version>
+		<jackson-databind-version>2.14.1</jackson-databind-version>
 		<jackson-databind-nullable-version>0.2.2</jackson-databind-nullable-version>
 		<jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 	</properties>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -93,7 +93,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.3</version>
+			<version>2.0.5</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 
 		<!--openapi client dependencies spring apache httpclient + jackson -->
-		<swagger-annotations-version>1.6.8</swagger-annotations-version>
+		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		<httpclient-version>4.5.13</httpclient-version>
 		<spring-web-version>5.3.19</spring-web-version>
 		<jackson-version>2.13.4</jackson-version>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.4</version>
+			<version>1.3.5</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.2.0</version>
+				<version>6.2.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="RestSharp" Version="108.0.2" />
     <PackageReference Include="Polly" Version="7.2.3" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -12,7 +12,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.2.0</version>
+				<version>6.2.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -18,7 +18,7 @@
 		<swagger-annotations-version>1.6.8</swagger-annotations-version>
 		<spring-web-version>5.3.23</spring-web-version>
 		<jackson-version>2.13.4</jackson-version>
-		<jackson-databind-version>2.13.4.2</jackson-databind-version>
+		<jackson-databind-version>2.14.1</jackson-databind-version>
 		<jackson-databind-nullable-version>0.2.3</jackson-databind-nullable-version>
 		<jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 	</properties>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -97,7 +97,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.3</version>
+			<version>2.0.5</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 
 		<!--openapi client dependencies: spring resttemplate+jackson -->
-		<swagger-annotations-version>1.6.8</swagger-annotations-version>
+		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		<spring-web-version>5.3.23</spring-web-version>
 		<jackson-version>2.13.4</jackson-version>
 		<jackson-databind-version>2.14.1</jackson-databind-version>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -114,7 +114,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.2.0</version>
+				<version>6.2.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.4</version>
+			<version>1.3.5</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -19,7 +19,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		
-		<springdoc.version>1.6.12</springdoc.version>
+		<springdoc.version>1.6.13</springdoc.version>
 	</properties>
 
 	<dependencies>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.2.0</version>
+				<version>6.2.1</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.5.2 to 3.6.1](https://github.com/javiertuya/samples-openapi/pull/93)
- [Bump logback-classic from 1.3.4 to 1.3.5](https://github.com/javiertuya/samples-openapi/pull/84)
- [Bump jackson-databind from 2.13.4.2 to 2.14.1](https://github.com/javiertuya/samples-openapi/pull/89)
- [Bump swagger-annotations from 1.6.8 to 1.6.9](https://github.com/javiertuya/samples-openapi/pull/81)
- [Bump openapi-generator-maven-plugin from 6.2.0 to 6.2.1](https://github.com/javiertuya/samples-openapi/pull/77)
- [Bump slf4j-api from 2.0.3 to 2.0.5](https://github.com/javiertuya/samples-openapi/pull/96)
- [Bump springdoc-openapi-ui from 1.6.12 to 1.6.13](https://github.com/javiertuya/samples-openapi/pull/86)
- [Bump Microsoft.NET.Test.Sdk from 17.3.2 to 17.4.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/80)
- [Bump Newtonsoft.Json from 13.0.1 to 13.0.2 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/92)

Does not include these updates because of merge conflicts:
- [Bump jackson-version from 2.13.4 to 2.14.1](https://github.com/javiertuya/samples-openapi/pull/88)
- [Bump jackson-databind-nullable from 0.2.3 to 0.2.4](https://github.com/javiertuya/samples-openapi/pull/75)
- [Bump NUnit3TestAdapter from 4.2.1 to 4.3.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/87)
- [Bump RestSharp from 108.0.2 to 108.0.3 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/85)