### PR TITLE
Combined dependency updates (2022-12-04)

### DIFF
--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<spring-web-version>5.3.23</spring-web-version>
+		<spring-web-version>5.3.24</spring-web-version>
 		
 		<jackson-version>2.14.1</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.5</version>
+		<version>2.7.6</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.openapitools</groupId>
 			<artifactId>jackson-databind-nullable</artifactId>
-			<version>0.2.3</version>
+			<version>0.2.4</version>
 		</dependency>
 		<!-- Bean Validation API support -->
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump jackson-databind-nullable from 0.2.3 to 0.2.4](https://github.com/javiertuya/samples-openapi/pull/75)
- [Bump spring-boot-starter-parent from 2.7.5 to 2.7.6](https://github.com/javiertuya/samples-openapi/pull/99)
- [Bump spring-web-version from 5.3.23 to 5.3.24](https://github.com/javiertuya/samples-openapi/pull/98)