### PR TITLE
Combined dependency updates (2022-12-16)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v3.6.1
+        uses: mikepenz/action-junit-report@v3.7.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>4.5.13</httpclient-version>
+		<httpclient-version>4.5.14</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -99,7 +99,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.5</version>
+			<version>2.0.6</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.5</version>
+			<version>2.0.6</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -19,7 +19,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		
-		<springdoc.version>1.6.13</springdoc.version>
+		<springdoc.version>1.6.14</springdoc.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.6.1 to 3.7.0](https://github.com/javiertuya/samples-openapi/pull/104)
- [Bump httpclient-version from 4.5.13 to 4.5.14](https://github.com/javiertuya/samples-openapi/pull/101)
- [Bump slf4j-api from 2.0.5 to 2.0.6](https://github.com/javiertuya/samples-openapi/pull/103)
- [Bump springdoc-openapi-ui from 1.6.13 to 1.6.14](https://github.com/javiertuya/samples-openapi/pull/105)
- [Bump Microsoft.NET.Test.Sdk from 17.4.0 to 17.4.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/106)