### PR TITLE
Combined dependency updates (2023-01-14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.0
+        uses: mikepenz/action-junit-report@v3.7.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<spring-web-version>5.3.24</spring-web-version>
+		<spring-web-version>5.3.25</spring-web-version>
 		
 		<jackson-version>2.14.1</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.6</version>
+		<version>2.7.7</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.0 to 3.7.1](https://github.com/javiertuya/samples-openapi/pull/109)
- [Bump spring-boot-starter-parent from 2.7.6 to 2.7.7](https://github.com/javiertuya/samples-openapi/pull/108)
- [Bump spring-web-version from 5.3.24 to 5.3.25](https://github.com/javiertuya/samples-openapi/pull/110)