### PR TITLE
Combined dependency updates (2023-02-05)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.14.1</jackson-version>
+		<jackson-version>2.14.2</jackson-version>
 		
 		<jackson-databind-version>2.14.2</jackson-databind-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.14.1</jackson-version>
 		
-		<jackson-databind-version>2.14.1</jackson-databind-version>
+		<jackson-databind-version>2.14.2</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.4</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -116,7 +116,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.2.1</version>
+				<version>6.3.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -12,7 +12,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.2.1</version>
+				<version>6.3.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.14.1</jackson-version>
 		
-		<jackson-databind-version>2.14.1</jackson-databind-version>
+		<jackson-databind-version>2.14.2</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.4</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>5.3.25</spring-web-version>
 		
-		<jackson-version>2.14.1</jackson-version>
+		<jackson-version>2.14.2</jackson-version>
 		
 		<jackson-databind-version>2.14.2</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.2.1</version>
+				<version>6.3.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.7</version>
+		<version>2.7.8</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -101,7 +101,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.2.1</version>
+				<version>6.3.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Includes these updates:
- [Bump jackson-databind from 2.14.1 to 2.14.2](https://github.com/javiertuya/samples-openapi/pull/114)
- [Bump jackson-version from 2.14.1 to 2.14.2](https://github.com/javiertuya/samples-openapi/pull/113)
- [Bump openapi-generator-maven-plugin from 6.2.1 to 6.3.0](https://github.com/javiertuya/samples-openapi/pull/115)
- [Bump spring-boot-starter-parent from 2.7.7 to 2.7.8](https://github.com/javiertuya/samples-openapi/pull/112)