### PR TITLE
Combined dependency updates (2023-02-18)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.1
+        uses: mikepenz/action-junit-report@v3.7.4
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-databind-version>2.14.2</jackson-databind-version>
 		
-		<jackson-databind-nullable-version>0.2.4</jackson-databind-nullable-version>
+		<jackson-databind-nullable-version>0.2.5</jackson-databind-nullable-version>
 		
 		<jakarta-annotation-version>2.1.1</jakarta-annotation-version>
 	</properties>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -63,7 +63,7 @@
 		<dependency>
 			<groupId>org.openapitools</groupId>
 			<artifactId>jackson-databind-nullable</artifactId>
-			<version>0.2.4</version>
+			<version>0.2.5</version>
 		</dependency>
 		<!-- Bean Validation API support -->
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.1 to 3.7.4](https://github.com/javiertuya/samples-openapi/pull/119)
- [Bump jackson-databind-nullable from 0.2.4 to 0.2.5](https://github.com/javiertuya/samples-openapi/pull/117)