### PR TITLE
Combined dependency updates (2023-03-10)

### DIFF
--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
   </ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     
     <PackageReference Include="RestSharp" Version="108.0.3" />
     

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -19,7 +19,7 @@
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		
-		<springdoc.version>1.6.14</springdoc.version>
+		<springdoc.version>1.6.15</springdoc.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump springdoc-openapi-ui from 1.6.14 to 1.6.15](https://github.com/javiertuya/samples-openapi/pull/130)
- [Bump NUnit3TestAdapter from 4.3.1 to 4.4.2 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/128)
- [Bump Newtonsoft.Json from 13.0.2 to 13.0.3 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/129)