### PR TITLE
Combined dependency updates (2023-03-26)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.6</version>
+			<version>2.0.7</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.6</version>
+			<version>2.0.7</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>1.8</maven.compiler.target>
 
 		<!--openapi client dependencies: spring resttemplate+jackson -->
-		<swagger-annotations-version>1.6.9</swagger-annotations-version>
+		<swagger-annotations-version>1.6.10</swagger-annotations-version>
 		
 		<spring-web-version>5.3.25</spring-web-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.10</swagger-annotations-version>
 		
-		<spring-web-version>5.3.25</spring-web-version>
+		<spring-web-version>5.3.26</spring-web-version>
 		
 		<jackson-version>2.14.2</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.9</version>
+		<version>2.7.10</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Includes these updates:
- [Bump swagger-annotations from 1.6.9 to 1.6.10](https://github.com/javiertuya/samples-openapi/pull/138)
- [Bump slf4j-api from 2.0.6 to 2.0.7](https://github.com/javiertuya/samples-openapi/pull/136)
- [Bump spring-boot-starter-parent from 2.7.9 to 2.7.10](https://github.com/javiertuya/samples-openapi/pull/139)
- [Bump spring-web-version from 5.3.25 to 5.3.26](https://github.com/javiertuya/samples-openapi/pull/137)