### PR TITLE
Combined dependency updates (2023-04-23)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.6</version>
+			<version>1.3.7</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.10</swagger-annotations-version>
 		
-		<spring-web-version>5.3.26</spring-web-version>
+		<spring-web-version>5.3.27</spring-web-version>
 		
 		<jackson-version>2.14.2</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -114,7 +114,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.6</version>
+			<version>1.3.7</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.10</version>
+		<version>2.7.11</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Includes these updates:
- [Bump logback-classic from 1.3.6 to 1.3.7](https://github.com/javiertuya/samples-openapi/pull/150)
- [Bump spring-boot-starter-parent from 2.7.10 to 2.7.11](https://github.com/javiertuya/samples-openapi/pull/149)
- [Bump spring-web-version from 5.3.26 to 5.3.27](https://github.com/javiertuya/samples-openapi/pull/148)