### PR TITLE
Combined dependency updates (2023-06-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.6
+        uses: mikepenz/action-junit-report@v3.7.7
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.15.1</jackson-version>
 		
-		<jackson-databind-version>2.15.1</jackson-databind-version>
+		<jackson-databind-version>2.15.2</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.15.1</jackson-version>
+		<jackson-version>2.15.2</jackson-version>
 		
 		<jackson-databind-version>2.15.2</jackson-databind-version>
 		

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.13.3" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.4.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
   </ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.15.1</jackson-version>
 		
-		<jackson-databind-version>2.15.1</jackson-databind-version>
+		<jackson-databind-version>2.15.2</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>5.3.27</spring-web-version>
 		
-		<jackson-version>2.15.1</jackson-version>
+		<jackson-version>2.15.2</jackson-version>
 		
 		<jackson-databind-version>2.15.2</jackson-databind-version>
 		


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.6 to 3.7.7](https://github.com/javiertuya/samples-openapi/pull/162)
- [Bump jackson-databind from 2.15.1 to 2.15.2](https://github.com/javiertuya/samples-openapi/pull/165)
- [Bump jackson-version from 2.15.1 to 2.15.2](https://github.com/javiertuya/samples-openapi/pull/164)
- [Bump Microsoft.NET.Test.Sdk from 17.6.0 to 17.6.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/166)
- [Bump NUnit3TestAdapter from 4.4.2 to 4.5.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/163)