### PR TITLE
Combined dependency updates (2023-06-17)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.7</version>
+			<version>1.3.8</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="108.0.3" />
     
-    <PackageReference Include="Polly" Version="7.2.3" />
+    <PackageReference Include="Polly" Version="7.2.4" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -114,7 +114,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.7</version>
+			<version>1.3.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.11</swagger-annotations-version>
 		
-		<spring-web-version>5.3.27</spring-web-version>
+		<spring-web-version>5.3.28</spring-web-version>
 		
 		<jackson-version>2.15.2</jackson-version>
 		


### PR DESCRIPTION
Includes these updates:
- [Bump logback-classic from 1.3.7 to 1.3.8](https://github.com/javiertuya/samples-openapi/pull/169)
- [Bump spring-web-version from 5.3.27 to 5.3.28](https://github.com/javiertuya/samples-openapi/pull/171)
- [Bump Microsoft.NET.Test.Sdk from 17.6.1 to 17.6.2 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/168)
- [Bump Polly from 7.2.3 to 7.2.4 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/170)