### PR TITLE
Combined dependency updates (2023-07-16)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v3.7.8
+        uses: mikepenz/action-junit-report@v3.8.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.11</swagger-annotations-version>
 		
-		<spring-web-version>5.3.28</spring-web-version>
+		<spring-web-version>5.3.29</spring-web-version>
 		
 		<jackson-version>2.15.2</jackson-version>
 		


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 3.7.8 to 3.8.0](https://github.com/javiertuya/samples-openapi/pull/178)
- [Bump spring-web-version from 5.3.28 to 5.3.29](https://github.com/javiertuya/samples-openapi/pull/177)
- [Bump Microsoft.NET.Test.Sdk from 17.6.2 to 17.6.3 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/176)