### PR TITLE
Combined dependency updates (2023-08-19)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -109,7 +109,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.8</version>
+			<version>1.3.11</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -114,7 +114,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.3.8</version>
+			<version>1.3.11</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/server-spring/Dockerfile
+++ b/server-spring/Dockerfile
@@ -1,7 +1,7 @@
 #Test api docs at localhost:8080
 #FROM eclipse-temurin:8-jre
 #updated by dependabot
-FROM eclipse-temurin:11-jre-alpine@sha256:44984e6bd1a3d394494ccfe8347f09595c2410fd4b345373bbd4b3b69d8cac50
+FROM eclipse-temurin:11-jre-alpine@sha256:1b3a73a450d23ba66d5854febd7a59230b389799a47af52eaa248e1fbfabd733
 EXPOSE 8080
 #RUN useradd -u 8877 server
 #USER server


### PR DESCRIPTION
Includes these updates:
- [Bump eclipse-temurin from `44984e6` to `1b3a73a` in /server-spring](https://github.com/javiertuya/samples-openapi/pull/187)
- [Bump ch.qos.logback:logback-classic from 1.3.8 to 1.3.11](https://github.com/javiertuya/samples-openapi/pull/185)
- [Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/186)