### PR TITLE
Combined dependency updates (2023-08-25)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -120,7 +120,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.6.0</version>
+				<version>7.0.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -20,7 +20,7 @@
     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     
-    <PackageReference Include="RestSharp" Version="108.0.3" />
+    <PackageReference Include="RestSharp" Version="110.2.0" />
     
     <PackageReference Include="Polly" Version="7.2.4" />
     

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -29,7 +29,7 @@
 						</goals>
 						<configuration>
 							<inputSpec>${project.parent.basedir}/schema/api.yml</inputSpec>
-							<generatorName>csharp-netcore</generatorName>
+							<generatorName>csharp</generatorName>
 							<generateAliasAsModel>true</generateAliasAsModel>
 							<packageName>Giis.Samples.Openapi</packageName>
 							<apiPackage>Api</apiPackage>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.6.0</version>
+				<version>7.0.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -125,7 +125,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.6.0</version>
+				<version>7.0.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.14</version>
+		<version>2.7.15</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>6.6.0</version>
+				<version>7.0.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Includes these updates:
- [Bump org.openapitools:openapi-generator-maven-plugin from 6.6.0 to 7.0.0](https://github.com/javiertuya/samples-openapi/pull/190)
- [Bump org.springframework.boot:spring-boot-starter-parent from 2.7.14 to 2.7.15](https://github.com/javiertuya/samples-openapi/pull/189)
- Fix openapi generator breaking changes e87cf0044411e14fd6444af2018b0a3a6750202e