### PR TITLE
Combined dependency updates (2023-09-08)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v3.8.0
+        uses: mikepenz/action-junit-report@v4.0.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v3.1.2
+        uses: actions/upload-artifact@v3.1.3
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Select Java Version
         uses: actions/setup-java@v3
         with:

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.7</version>
+			<version>2.0.9</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.7</version>
+			<version>2.0.9</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/checkout from 3 to 4](https://github.com/javiertuya/samples-openapi/pull/194)
- [Bump actions/upload-artifact from 3.1.2 to 3.1.3](https://github.com/javiertuya/samples-openapi/pull/196)
- [Bump mikepenz/action-junit-report from 3.8.0 to 4.0.0](https://github.com/javiertuya/samples-openapi/pull/195)
- [Bump org.slf4j:slf4j-api from 2.0.7 to 2.0.9](https://github.com/javiertuya/samples-openapi/pull/193)
- [Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/192)