### PR TITLE
Combined dependency updates (2023-09-22)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -120,7 +120,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.0.0</version>
+				<version>7.0.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.0.0</version>
+				<version>7.0.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.11</swagger-annotations-version>
 		
-		<spring-web-version>5.3.29</spring-web-version>
+		<spring-web-version>5.3.30</spring-web-version>
 		
 		<jackson-version>2.15.2</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -125,7 +125,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.0.0</version>
+				<version>7.0.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.0.0</version>
+				<version>7.0.1</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.7.15</version>
+		<version>2.7.16</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Includes these updates:
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.0.0 to 7.0.1](https://github.com/javiertuya/samples-openapi/pull/199)
- [Bump org.springframework.boot:spring-boot-starter-parent from 2.7.15 to 2.7.16](https://github.com/javiertuya/samples-openapi/pull/200)
- [Bump spring-web-version from 5.3.29 to 5.3.30](https://github.com/javiertuya/samples-openapi/pull/198)