### PR TITLE
Combined dependency updates (2023-10-06)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,8 +28,6 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 20
-    assignees:
-      - "javiertuya" 
 
   - package-ecosystem: docker
     directory: "/server-spring/"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.0
+        uses: mikepenz/action-junit-report@v4.0.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="110.2.0" />
     
-    <PackageReference Include="Polly" Version="7.2.4" />
+    <PackageReference Include="Polly" Version="8.0.0" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Update dependabot.yml assignee](https://github.com/javiertuya/samples-openapi/pull/204)
- [Bump mikepenz/action-junit-report from 4.0.0 to 4.0.1](https://github.com/javiertuya/samples-openapi/pull/203)
- [Bump Polly from 7.2.4 to 8.0.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/202)