### PR TITLE
Combined dependency updates (2023-10-14)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.15.2</jackson-version>
 		
-		<jackson-databind-version>2.15.2</jackson-databind-version>
+		<jackson-databind-version>2.15.3</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.15.2</jackson-version>
+		<jackson-version>2.15.3</jackson-version>
 		
 		<jackson-databind-version>2.15.3</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>5.3.30</spring-web-version>
 		
-		<jackson-version>2.15.2</jackson-version>
+		<jackson-version>2.15.3</jackson-version>
 		
 		<jackson-databind-version>2.15.3</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.15.2</jackson-version>
 		
-		<jackson-databind-version>2.15.2</jackson-databind-version>
+		<jackson-databind-version>2.15.3</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		


### PR DESCRIPTION
Includes these updates:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.15.2 to 2.15.3](https://github.com/javiertuya/samples-openapi/pull/207)
- [Bump jackson-version from 2.15.2 to 2.15.3](https://github.com/javiertuya/samples-openapi/pull/206)