### PR TITLE
Combined dependency updates (2023-10-20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.1
+        uses: mikepenz/action-junit-report@v4.0.3
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!--openapi client dependencies: spring resttemplate+jackson -->
-		<swagger-annotations-version>1.6.11</swagger-annotations-version>
+		<swagger-annotations-version>1.6.12</swagger-annotations-version>
 		
 		<spring-web-version>6.0.13</spring-web-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.4</version>
+		<version>3.1.5</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.1 to 4.0.3](https://github.com/javiertuya/samples-openapi/pull/212)
- [Bump io.swagger:swagger-annotations from 1.6.11 to 1.6.12](https://github.com/javiertuya/samples-openapi/pull/209)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.1.4 to 3.1.5](https://github.com/javiertuya/samples-openapi/pull/210)