### PR TITLE
Combined dependency updates (2023-11-04)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.21.0</version>
+		    <version>2.21.1</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="110.2.0" />
     
-    <PackageReference Include="Polly" Version="8.0.0" />
+    <PackageReference Include="Polly" Version="8.1.0" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/server-spring/Dockerfile
+++ b/server-spring/Dockerfile
@@ -1,6 +1,6 @@
 #Test api docs at localhost:8080
 #updated by dependabot
-FROM eclipse-temurin:17-jre-alpine@sha256:532dc48a91112108f012784618213767e7458368b51b77d37a1a076cd7e70ef8
+FROM eclipse-temurin:17-jre-alpine@sha256:984703da8353d0a33eb04944b56665e84c6271e5d4f8a679e73cb5bd2b846301
 EXPOSE 8080
 #RUN useradd -u 8877 server
 #USER server


### PR DESCRIPTION
Includes these updates:
- [Bump eclipse-temurin from `532dc48` to `984703d` in /server-spring](https://github.com/javiertuya/samples-openapi/pull/215)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.21.0 to 2.21.1](https://github.com/javiertuya/samples-openapi/pull/214)
- [Bump Polly from 8.0.0 to 8.1.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/216)