### PR TITLE
Combined dependency updates (2023-11-18)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.15.3</jackson-version>
 		
-		<jackson-databind-version>2.15.3</jackson-databind-version>
+		<jackson-databind-version>2.16.0</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.15.3</jackson-version>
+		<jackson-version>2.16.0</jackson-version>
 		
 		<jackson-databind-version>2.16.0</jackson-databind-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.0.1</version>
+				<version>7.1.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="110.2.0" />
     
-    <PackageReference Include="Polly" Version="8.1.0" />
+    <PackageReference Include="Polly" Version="8.2.0" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.0.1</version>
+				<version>7.1.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.12</swagger-annotations-version>
 		
-		<spring-web-version>6.0.13</spring-web-version>
+		<spring-web-version>6.1.0</spring-web-version>
 		
 		<jackson-version>2.16.0</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.15.3</jackson-version>
 		
-		<jackson-databind-version>2.15.3</jackson-databind-version>
+		<jackson-databind-version>2.16.0</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.0.1</version>
+				<version>7.1.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.0.13</spring-web-version>
 		
-		<jackson-version>2.15.3</jackson-version>
+		<jackson-version>2.16.0</jackson-version>
 		
 		<jackson-databind-version>2.16.0</jackson-databind-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.0.1</version>
+				<version>7.1.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Includes these updates:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.15.3 to 2.16.0](https://github.com/javiertuya/samples-openapi/pull/223)
- [Bump jackson-version from 2.15.3 to 2.16.0](https://github.com/javiertuya/samples-openapi/pull/222)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.0.1 to 7.1.0](https://github.com/javiertuya/samples-openapi/pull/220)
- [Bump spring-web-version from 6.0.13 to 6.1.0](https://github.com/javiertuya/samples-openapi/pull/224)
- [Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/219)
- [Bump NUnit from 3.13.3 to 3.14.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/218)
- [Bump Polly from 8.1.0 to 8.2.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/221)