### PR TITLE
Combined dependency updates (2023-11-18)

### DIFF
--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit" Version="3.14.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="110.2.0" />
     
-    <PackageReference Include="Polly" Version="8.1.0" />
+    <PackageReference Include="Polly" Version="8.2.0" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Includes these updates:
- [Bump Microsoft.NET.Test.Sdk from 17.7.2 to 17.8.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/219)
- [Bump NUnit from 3.13.3 to 3.14.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/218)
- [Bump Polly from 8.1.0 to 8.2.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/221)