### PR TITLE
Combined dependency updates (2023-11-25)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.2.1</httpclient-version>
+		<httpclient-version>5.2.2</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.21.1</version>
+		    <version>2.22.0</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.12</swagger-annotations-version>
 		
-		<spring-web-version>6.1.0</spring-web-version>
+		<spring-web-version>6.1.1</spring-web-version>
 		
 		<jackson-version>2.16.0</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.5</version>
+		<version>3.2.0</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Includes these updates:
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.2.1 to 5.2.2](https://github.com/javiertuya/samples-openapi/pull/230)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.21.1 to 2.22.0](https://github.com/javiertuya/samples-openapi/pull/227)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.1.5 to 3.2.0](https://github.com/javiertuya/samples-openapi/pull/231)
- [Bump spring-web-version from 6.1.0 to 6.1.1](https://github.com/javiertuya/samples-openapi/pull/228)