### PR TITLE
Combined dependency updates (2023-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.2.2</httpclient-version>
+		<httpclient-version>5.2.3</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.0.0" />
+    <PackageReference Include="NUnit" Version="4.0.1" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.4.11</version>
+			<version>1.4.14</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-java from 3 to 4](https://github.com/javiertuya/samples-openapi/pull/236)
- [Bump ch.qos.logback:logback-classic from 1.4.11 to 1.4.14](https://github.com/javiertuya/samples-openapi/pull/238)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.2.2 to 5.2.3](https://github.com/javiertuya/samples-openapi/pull/237)
- [Bump NUnit from 4.0.0 to 4.0.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/239)