### PR TITLE
Combined dependency updates (2023-12-17)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4.0.0
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: mvn test -pl client-resttemplate,client-httpclient -Dmaven.test.failure.ignore=false -U --no-transfer-progress
 
       - name: Netcore Client - Prepare environment
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@v4
         with:
             dotnet-version: '6.0.x'
 

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.2.3</httpclient-version>
+		<httpclient-version>5.3</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.12</swagger-annotations-version>
 		
-		<spring-web-version>6.1.1</spring-web-version>
+		<spring-web-version>6.1.2</spring-web-version>
 		
 		<jackson-version>2.16.0</jackson-version>
 		


### PR DESCRIPTION
Includes these updates:
- [Bump actions/setup-dotnet from 3 to 4](https://github.com/javiertuya/samples-openapi/pull/241)
- [Bump actions/upload-artifact from 3.1.3 to 4.0.0](https://github.com/javiertuya/samples-openapi/pull/244)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.2.3 to 5.3](https://github.com/javiertuya/samples-openapi/pull/242)
- [Bump spring-web-version from 6.1.1 to 6.1.2](https://github.com/javiertuya/samples-openapi/pull/243)