### PR TITLE
Combined dependency updates (2023-12-30)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.16.0</jackson-version>
+		<jackson-version>2.16.1</jackson-version>
 		
 		<jackson-databind-version>2.16.1</jackson-databind-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.9</version>
+			<version>2.0.10</version>
 			<scope>compile</scope>
 		</dependency>
 		<!-- instead of logback (default in spring) uses the apache log4j binding -->

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.22.0</version>
+		    <version>2.22.1</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.16.0</jackson-version>
 		
-		<jackson-databind-version>2.16.0</jackson-databind-version>
+		<jackson-databind-version>2.16.1</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.1.2</spring-web-version>
 		
-		<jackson-version>2.16.0</jackson-version>
+		<jackson-version>2.16.1</jackson-version>
 		
 		<jackson-databind-version>2.16.1</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.9</version>
+			<version>2.0.10</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.16.0</jackson-version>
 		
-		<jackson-databind-version>2.16.0</jackson-databind-version>
+		<jackson-databind-version>2.16.1</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		


### PR DESCRIPTION
Includes these updates:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.16.0 to 2.16.1](https://github.com/javiertuya/samples-openapi/pull/250)
- [Bump jackson-version from 2.16.0 to 2.16.1](https://github.com/javiertuya/samples-openapi/pull/249)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.22.0 to 2.22.1](https://github.com/javiertuya/samples-openapi/pull/251)
- [Bump org.slf4j:slf4j-api from 2.0.9 to 2.0.10](https://github.com/javiertuya/samples-openapi/pull/252)