### PR TITLE
Combined dependency updates (2024-01-14)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.3
+        uses: mikepenz/action-junit-report@v4.0.4
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.10</version>
+			<version>2.0.11</version>
 			<scope>compile</scope>
 		</dependency>
 		<!-- instead of logback (default in spring) uses the apache log4j binding -->

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="110.2.0" />
     
-    <PackageReference Include="Polly" Version="8.2.0" />
+    <PackageReference Include="Polly" Version="8.2.1" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.10</version>
+			<version>2.0.11</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.12</swagger-annotations-version>
 		
-		<spring-web-version>6.1.2</spring-web-version>
+		<spring-web-version>6.1.3</spring-web-version>
 		
 		<jackson-version>2.16.1</jackson-version>
 		


### PR DESCRIPTION
Includes these updates:
- [Bump mikepenz/action-junit-report from 4.0.3 to 4.0.4](https://github.com/javiertuya/samples-openapi/pull/257)
- [Bump org.slf4j:slf4j-api from 2.0.10 to 2.0.11](https://github.com/javiertuya/samples-openapi/pull/255)
- [Bump spring-web-version from 6.1.2 to 6.1.3](https://github.com/javiertuya/samples-openapi/pull/256)
- [Bump Polly from 8.2.0 to 8.2.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/254)