### PR TITLE
Combined dependency updates (2024-01-27)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.0.0
+        uses: actions/upload-artifact@v4.3.0
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.3</httpclient-version>
+		<httpclient-version>5.3.1</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!--openapi client dependencies: spring resttemplate+jackson -->
-		<swagger-annotations-version>1.6.12</swagger-annotations-version>
+		<swagger-annotations-version>1.6.13</swagger-annotations-version>
 		
 		<spring-web-version>6.1.3</spring-web-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.1</version>
+		<version>3.2.2</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/upload-artifact from 4.0.0 to 4.3.0](https://github.com/javiertuya/samples-openapi/pull/262)
- [Bump io.swagger:swagger-annotations from 1.6.12 to 1.6.13](https://github.com/javiertuya/samples-openapi/pull/264)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.3 to 5.3.1](https://github.com/javiertuya/samples-openapi/pull/263)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.1 to 3.2.2](https://github.com/javiertuya/samples-openapi/pull/261)