### PR TITLE
Combined dependency updates (2024-02-10)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.0.4
+        uses: mikepenz/action-junit-report@v4.1.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.3.0
+        uses: actions/upload-artifact@v4.3.1
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.2.0</version>
+				<version>7.3.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.11</version>
+			<version>2.0.12</version>
 			<scope>compile</scope>
 		</dependency>
 		<!-- instead of logback (default in spring) uses the apache log4j binding -->

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="110.2.0" />
     
-    <PackageReference Include="Polly" Version="8.2.1" />
+    <PackageReference Include="Polly" Version="8.3.0" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.2.0</version>
+				<version>7.3.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.2.0</version>
+				<version>7.3.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.11</version>
+			<version>2.0.12</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.2.0</version>
+				<version>7.3.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Includes these updates:
- [Bump actions/upload-artifact from 4.3.0 to 4.3.1](https://github.com/javiertuya/samples-openapi/pull/268)
- [Bump mikepenz/action-junit-report from 4.0.4 to 4.1.0](https://github.com/javiertuya/samples-openapi/pull/266)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.2.0 to 7.3.0](https://github.com/javiertuya/samples-openapi/pull/271)
- [Bump org.slf4j:slf4j-api from 2.0.11 to 2.0.12](https://github.com/javiertuya/samples-openapi/pull/269)
- [Bump Microsoft.NET.Test.Sdk from 17.8.0 to 17.9.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/270)
- [Bump Polly from 8.2.1 to 8.3.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/267)