### PR TITLE
Combined dependency updates (2024-02-24)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.22.1</version>
+		    <version>2.23.0</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.4.14</version>
+			<version>1.5.0</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.13</swagger-annotations-version>
 		
-		<spring-web-version>6.1.3</spring-web-version>
+		<spring-web-version>6.1.4</spring-web-version>
 		
 		<jackson-version>2.16.1</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.2</version>
+		<version>3.2.3</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Includes these updates:
- [Bump ch.qos.logback:logback-classic from 1.4.14 to 1.5.0](https://github.com/javiertuya/samples-openapi/pull/274)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.22.1 to 2.23.0](https://github.com/javiertuya/samples-openapi/pull/275)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.2 to 3.2.3](https://github.com/javiertuya/samples-openapi/pull/276)
- [Bump spring-web-version from 6.1.3 to 6.1.4](https://github.com/javiertuya/samples-openapi/pull/273)