### PR TITLE
Combined dependency updates (2024-03-09)

### DIFF
--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="110.2.0" />
     
-    <PackageReference Include="Polly" Version="8.3.0" />
+    <PackageReference Include="Polly" Version="8.3.1" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.1</version>
+			<version>1.5.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Polly from 8.3.0 to 8.3.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/282)
- [Bump ch.qos.logback:logback-classic from 1.5.1 to 1.5.3](https://github.com/javiertuya/samples-openapi/pull/281)