### PR TITLE
Combined dependency updates (2024-03-16)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.1.0
+        uses: mikepenz/action-junit-report@v4.2.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.16.1</jackson-version>
+		<jackson-version>2.17.0</jackson-version>
 		
 		<jackson-databind-version>2.17.0</jackson-databind-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.3.0</version>
+				<version>7.4.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.23.0</version>
+		    <version>2.23.1</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.16.1</jackson-version>
 		
-		<jackson-databind-version>2.16.1</jackson-databind-version>
+		<jackson-databind-version>2.17.0</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.3.0</version>
+				<version>7.4.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.1.5</spring-web-version>
 		
-		<jackson-version>2.16.1</jackson-version>
+		<jackson-version>2.17.0</jackson-version>
 		
 		<jackson-databind-version>2.17.0</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.13</swagger-annotations-version>
 		
-		<spring-web-version>6.1.4</spring-web-version>
+		<spring-web-version>6.1.5</spring-web-version>
 		
 		<jackson-version>2.16.1</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.3.0</version>
+				<version>7.4.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.16.1</jackson-version>
 		
-		<jackson-databind-version>2.16.1</jackson-databind-version>
+		<jackson-databind-version>2.17.0</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -19,7 +19,7 @@
 		<maven.compiler.source>17</maven.compiler.source>
 		<maven.compiler.target>17</maven.compiler.target>
 		
-		<springdoc.version>1.7.0</springdoc.version>
+		<springdoc.version>1.8.0</springdoc.version>
 	</properties>
 
 	<dependencies>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.3.0</version>
+				<version>7.4.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump spring-web-version from 6.1.4 to 6.1.5](https://github.com/javiertuya/samples-openapi/pull/292)
- [Bump mikepenz/action-junit-report from 4.1.0 to 4.2.1](https://github.com/javiertuya/samples-openapi/pull/291)
- [Bump org.springdoc:springdoc-openapi-ui from 1.7.0 to 1.8.0](https://github.com/javiertuya/samples-openapi/pull/290)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.16.1 to 2.17.0](https://github.com/javiertuya/samples-openapi/pull/289)
- [Bump jackson-version from 2.16.1 to 2.17.0](https://github.com/javiertuya/samples-openapi/pull/288)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.3.0 to 7.4.0](https://github.com/javiertuya/samples-openapi/pull/285)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.23.0 to 2.23.1](https://github.com/javiertuya/samples-openapi/pull/284)