### PR TITLE
Combined dependency updates (2024-03-30)

### DIFF
--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!--openapi client dependencies: spring resttemplate+jackson -->
-		<swagger-annotations-version>1.6.13</swagger-annotations-version>
+		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
 		<spring-web-version>6.1.5</spring-web-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.3</version>
+		<version>3.2.4</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.3 to 3.2.4](https://github.com/javiertuya/samples-openapi/pull/295)
- [Bump io.swagger:swagger-annotations from 1.6.13 to 1.6.14](https://github.com/javiertuya/samples-openapi/pull/294)