### PR TITLE
Combined dependency updates (2024-04-13)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -27,7 +27,7 @@
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		
-		<jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 	</properties>
 
 	<dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.3</version>
+			<version>1.5.4</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.1.5</spring-web-version>
+		<spring-web-version>6.1.6</spring-web-version>
 		
 		<jackson-version>2.17.0</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -25,7 +25,7 @@
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		
-		<jakarta-annotation-version>2.1.1</jakarta-annotation-version>
+		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump spring-web-version from 6.1.5 to 6.1.6](https://github.com/javiertuya/samples-openapi/pull/299)
- [Bump ch.qos.logback:logback-classic from 1.5.3 to 1.5.4](https://github.com/javiertuya/samples-openapi/pull/298)
- [Bump jakarta.annotation:jakarta.annotation-api from 2.1.1 to 3.0.0](https://github.com/javiertuya/samples-openapi/pull/297)