### PR TITLE
Combined dependency updates (2024-04-20)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@v4.3.2
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.4.0</version>
+				<version>7.5.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.12</version>
+			<version>2.0.13</version>
 			<scope>compile</scope>
 		</dependency>
 		<!-- instead of logback (default in spring) uses the apache log4j binding -->

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.4.0</version>
+				<version>7.5.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.4.0</version>
+				<version>7.5.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.4</version>
+			<version>1.5.6</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.12</version>
+			<version>2.0.13</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.4</version>
+		<version>3.2.5</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.4.0</version>
+				<version>7.5.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.4 to 3.2.5](https://github.com/javiertuya/samples-openapi/pull/306)
- [Bump actions/upload-artifact from 4.3.1 to 4.3.2](https://github.com/javiertuya/samples-openapi/pull/305)
- [Bump ch.qos.logback:logback-classic from 1.5.4 to 1.5.6](https://github.com/javiertuya/samples-openapi/pull/304)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.4.0 to 7.5.0](https://github.com/javiertuya/samples-openapi/pull/303)
- [Bump org.slf4j:slf4j-api from 2.0.12 to 2.0.13](https://github.com/javiertuya/samples-openapi/pull/302)