### PR TITLE
Combined dependency updates (2024-05-25)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.5.0</version>
+				<version>7.6.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.5.0</version>
+				<version>7.6.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.1.7</spring-web-version>
+		<spring-web-version>6.1.8</spring-web-version>
 		
 		<jackson-version>2.17.1</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.5.0</version>
+				<version>7.6.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.2.5</version>
+		<version>3.3.0</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.5.0</version>
+				<version>7.6.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.2.5 to 3.3.0](https://github.com/javiertuya/samples-openapi/pull/318)
- [Bump spring-web-version from 6.1.7 to 6.1.8](https://github.com/javiertuya/samples-openapi/pull/317)
- [Bump Microsoft.NET.Test.Sdk from 17.9.0 to 17.10.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/316)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.5.0 to 7.6.0](https://github.com/javiertuya/samples-openapi/pull/314)