### PR TITLE
Combined dependency updates (2024-06-15)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.2.1
+        uses: mikepenz/action-junit-report@v4.2.2
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.1.8</spring-web-version>
+		<spring-web-version>6.1.9</spring-web-version>
 		
 		<jackson-version>2.17.1</jackson-version>
 		


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump spring-web-version from 6.1.8 to 6.1.9](https://github.com/javiertuya/samples-openapi/pull/322)
- [Bump mikepenz/action-junit-report from 4.2.1 to 4.2.2](https://github.com/javiertuya/samples-openapi/pull/321)