### PR TITLE
Combined dependency updates (2024-06-22)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.2.2
+        uses: mikepenz/action-junit-report@v4.3.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.1.9</spring-web-version>
+		<spring-web-version>6.1.10</spring-web-version>
 		
 		<jackson-version>2.17.1</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.0</version>
+		<version>3.3.1</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 4.2.2 to 4.3.0](https://github.com/javiertuya/samples-openapi/pull/326)
- [Bump spring-web-version from 6.1.9 to 6.1.10](https://github.com/javiertuya/samples-openapi/pull/325)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.3.0 to 3.3.1](https://github.com/javiertuya/samples-openapi/pull/324)