### PR TITLE
Combined dependency updates (2024-07-06)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.3.0
+        uses: mikepenz/action-junit-report@v4.3.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.6.0</version>
+				<version>7.7.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="110.2.0" />
     
-    <PackageReference Include="Polly" Version="8.4.0" />
+    <PackageReference Include="Polly" Version="8.4.1" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.6.0</version>
+				<version>7.7.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.6.0</version>
+				<version>7.7.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.6.0</version>
+				<version>7.7.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.6.0 to 7.7.0](https://github.com/javiertuya/samples-openapi/pull/330)
- [Bump Polly from 8.4.0 to 8.4.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/329)
- [Bump mikepenz/action-junit-report from 4.3.0 to 4.3.1](https://github.com/javiertuya/samples-openapi/pull/328)