### PR TITLE
Combined dependency updates (2024-07-13)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.3.3
+        uses: actions/upload-artifact@v4.3.4
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.17.1</jackson-version>
+		<jackson-version>2.17.2</jackson-version>
 		
 		<jackson-databind-version>2.17.2</jackson-databind-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.17.1</jackson-version>
 		
-		<jackson-databind-version>2.17.1</jackson-databind-version>
+		<jackson-databind-version>2.17.2</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.1.11</spring-web-version>
 		
-		<jackson-version>2.17.1</jackson-version>
+		<jackson-version>2.17.2</jackson-version>
 		
 		<jackson-databind-version>2.17.2</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.17.1</jackson-version>
 		
-		<jackson-databind-version>2.17.1</jackson-databind-version>
+		<jackson-databind-version>2.17.2</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.1.10</spring-web-version>
+		<spring-web-version>6.1.11</spring-web-version>
 		
 		<jackson-version>2.17.1</jackson-version>
 		


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump spring-web-version from 6.1.10 to 6.1.11](https://github.com/javiertuya/samples-openapi/pull/335)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.17.1 to 2.17.2](https://github.com/javiertuya/samples-openapi/pull/334)
- [Bump jackson-version from 2.17.1 to 2.17.2](https://github.com/javiertuya/samples-openapi/pull/333)
- [Bump actions/upload-artifact from 4.3.3 to 4.3.4](https://github.com/javiertuya/samples-openapi/pull/332)