### PR TITLE
Combined dependency updates (2024-09-13)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.23.1</version>
+		    <version>2.24.0</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -20,7 +20,7 @@
     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
     
     <PackageReference Include="Polly" Version="8.4.1" />
     

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.7</version>
+			<version>1.5.8</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.1.12</spring-web-version>
+		<spring-web-version>6.1.13</spring-web-version>
 		
 		<jackson-version>2.17.2</jackson-version>
 		


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump spring-web-version from 6.1.12 to 6.1.13](https://github.com/javiertuya/samples-openapi/pull/358)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.23.1 to 2.24.0](https://github.com/javiertuya/samples-openapi/pull/357)
- [Bump ch.qos.logback:logback-classic from 1.5.7 to 1.5.8](https://github.com/javiertuya/samples-openapi/pull/356)
- [Bump Microsoft.NET.Test.Sdk from 17.11.0 to 17.11.1 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/355)
- [Bump actions/upload-artifact from 4.3.6 to 4.4.0](https://github.com/javiertuya/samples-openapi/pull/354)
- [Bump NUnit from 4.2.1 to 4.2.2 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/353)
- [Bump RestSharp from 110.2.0 to 112.0.0 in /client-netcore/client-netcore](https://github.com/javiertuya/samples-openapi/pull/352)