### PR TITLE
Combined dependency updates (2024-09-28)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.3.1</httpclient-version>
+		<httpclient-version>5.4</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.17.2</jackson-version>
+		<jackson-version>2.18.0</jackson-version>
 		
 		<jackson-databind-version>2.18.0</jackson-databind-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.17.2</jackson-version>
 		
-		<jackson-databind-version>2.17.2</jackson-databind-version>
+		<jackson-databind-version>2.18.0</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="112.0.0" />
     
-    <PackageReference Include="Polly" Version="8.4.1" />
+    <PackageReference Include="Polly" Version="8.4.2" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.17.2</jackson-version>
 		
-		<jackson-databind-version>2.17.2</jackson-databind-version>
+		<jackson-databind-version>2.18.0</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.1.13</spring-web-version>
 		
-		<jackson-version>2.17.2</jackson-version>
+		<jackson-version>2.18.0</jackson-version>
 		
 		<jackson-databind-version>2.18.0</jackson-databind-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.3</version>
+		<version>3.3.4</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.17.2 to 2.18.0](https://github.com/javiertuya/samples-openapi/pull/364)
- [Bump jackson-version from 2.17.2 to 2.18.0](https://github.com/javiertuya/samples-openapi/pull/363)
- [Bump Polly from 8.4.1 to 8.4.2 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/362)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.3.1 to 5.4](https://github.com/javiertuya/samples-openapi/pull/361)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.3.3 to 3.3.4](https://github.com/javiertuya/samples-openapi/pull/360)