### PR TITLE
Combined dependency updates (2024-10-12)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.4.0
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.24.0</version>
+		    <version>2.24.1</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -20,7 +20,7 @@
     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     
-    <PackageReference Include="RestSharp" Version="112.0.0" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
     
     <PackageReference Include="Polly" Version="8.4.2" />
     

--- a/client-netstandard/client-netstandard/client-netstandard.csproj
+++ b/client-netstandard/client-netstandard/client-netstandard.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     
-    <PackageReference Include="RestSharp" Version="112.0.0" />
+    <PackageReference Include="RestSharp" Version="112.1.0" />
     
     <PackageReference Include="Polly" Version="8.4.2" />
     

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.8</version>
+			<version>1.5.9</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-artifact from 4.4.0 to 4.4.3](https://github.com/javiertuya/samples-openapi/pull/371)
- [Bump ch.qos.logback:logback-classic from 1.5.8 to 1.5.9](https://github.com/javiertuya/samples-openapi/pull/370)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.24.0 to 2.24.1](https://github.com/javiertuya/samples-openapi/pull/366)
- [Bump RestSharp from 112.0.0 to 112.1.0 in /client-netstandard](https://github.com/javiertuya/samples-openapi/pull/373)
- [Bump RestSharp from 112.0.0 to 112.1.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/372)