### PR TITLE
Combined dependency updates (2024-10-25)

### DIFF
--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.9</version>
+			<version>1.5.11</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.1.13</spring-web-version>
+		<spring-web-version>6.1.14</spring-web-version>
 		
 		<jackson-version>2.18.0</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.4</version>
+		<version>3.3.5</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.3.4 to 3.3.5](https://github.com/javiertuya/samples-openapi/pull/380)
- [Bump org.springframework:spring-context from 6.1.13 to 6.1.14 in /client-resttemplate](https://github.com/javiertuya/samples-openapi/pull/379)
- [Bump spring-web-version from 6.1.13 to 6.1.14](https://github.com/javiertuya/samples-openapi/pull/378)
- [Bump ch.qos.logback:logback-classic from 1.5.9 to 1.5.11](https://github.com/javiertuya/samples-openapi/pull/377)