### PR TITLE
Combined dependency updates (2024-11-02)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.4</httpclient-version>
+		<httpclient-version>5.4.1</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.18.1</jackson-version>
 		
-		<jackson-databind-version>2.18.0</jackson-databind-version>
+		<jackson-databind-version>2.18.1</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.18.0</jackson-version>
+		<jackson-version>2.18.1</jackson-version>
 		
 		<jackson-databind-version>2.18.0</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.11</version>
+			<version>1.5.12</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.1.14</spring-web-version>
 		
-		<jackson-version>2.18.0</jackson-version>
+		<jackson-version>2.18.1</jackson-version>
 		
 		<jackson-databind-version>2.18.0</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.18.1</jackson-version>
 		
-		<jackson-databind-version>2.18.0</jackson-databind-version>
+		<jackson-databind-version>2.18.1</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.4 to 5.4.1](https://github.com/javiertuya/samples-openapi/pull/385)
- [Bump jackson-version from 2.18.0 to 2.18.1](https://github.com/javiertuya/samples-openapi/pull/384)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.18.0 to 2.18.1](https://github.com/javiertuya/samples-openapi/pull/383)
- [Bump ch.qos.logback:logback-classic from 1.5.11 to 1.5.12](https://github.com/javiertuya/samples-openapi/pull/382)