### PR TITLE
Combined dependency updates (2024-11-23)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v4.3.1
+        uses: mikepenz/action-junit-report@v5.0.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.9.0</version>
+				<version>7.10.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.24.1</version>
+		    <version>2.24.2</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     
-    <PackageReference Include="Polly" Version="8.4.2" />
+    <PackageReference Include="Polly" Version="8.5.0" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.9.0</version>
+				<version>7.10.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
+++ b/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netstandard/client-netstandard/client-netstandard.csproj
+++ b/client-netstandard/client-netstandard/client-netstandard.csproj
@@ -14,7 +14,7 @@
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     
-    <PackageReference Include="Polly" Version="8.4.2" />
+    <PackageReference Include="Polly" Version="8.5.0" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netstandard/pom.xml
+++ b/client-netstandard/pom.xml
@@ -13,7 +13,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.9.0</version>
+				<version>7.10.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.1.14</spring-web-version>
+		<spring-web-version>6.2.0</spring-web-version>
 		
 		<jackson-version>2.18.1</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.9.0</version>
+				<version>7.10.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.5</version>
+		<version>3.4.0</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.9.0</version>
+				<version>7.10.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.24.1 to 2.24.2](https://github.com/javiertuya/samples-openapi/pull/397)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.3.5 to 3.4.0](https://github.com/javiertuya/samples-openapi/pull/396)
- [Bump Microsoft.NET.Test.Sdk from 17.11.1 to 17.12.0 in /client-netstandard](https://github.com/javiertuya/samples-openapi/pull/394)
- [Bump Newtonsoft.Json and Microsoft.NET.Test.Sdk in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/393)
- [Bump mikepenz/action-junit-report from 4.3.1 to 5.0.0](https://github.com/javiertuya/samples-openapi/pull/392)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.9.0 to 7.10.0](https://github.com/javiertuya/samples-openapi/pull/391)
- [Bump spring-web-version from 6.1.14 to 6.2.0](https://github.com/javiertuya/samples-openapi/pull/390)
- [Bump Polly and System.ComponentModel.Annotations in /client-netstandard](https://github.com/javiertuya/samples-openapi/pull/389)
- [Bump Polly from 8.4.2 to 8.5.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/388)