### PR TITLE
Combined dependency updates (2024-12-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v5.0.0
+        uses: mikepenz/action-junit-report@v5.1.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.18.1</jackson-version>
 		
-		<jackson-databind-version>2.18.1</jackson-databind-version>
+		<jackson-databind-version>2.18.2</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.18.1</jackson-version>
+		<jackson-version>2.18.2</jackson-version>
 		
 		<jackson-databind-version>2.18.2</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.2.0</spring-web-version>
 		
-		<jackson-version>2.18.1</jackson-version>
+		<jackson-version>2.18.2</jackson-version>
 		
 		<jackson-databind-version>2.18.2</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.18.1</jackson-version>
 		
-		<jackson-databind-version>2.18.1</jackson-databind-version>
+		<jackson-databind-version>2.18.2</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump mikepenz/action-junit-report from 5.0.0 to 5.1.0](https://github.com/javiertuya/samples-openapi/pull/402)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.18.1 to 2.18.2](https://github.com/javiertuya/samples-openapi/pull/401)
- [Bump jackson-version from 2.18.1 to 2.18.2](https://github.com/javiertuya/samples-openapi/pull/400)