### PR TITLE
Combined dependency updates (2024-12-15)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v5.1.0
+        uses: mikepenz/action-junit-report@v5.2.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -110,7 +110,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.24.2</version>
+		    <version>2.24.3</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit" Version="4.3.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     

--- a/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
+++ b/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.2.2" />
+    <PackageReference Include="NUnit" Version="4.3.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.14</swagger-annotations-version>
 		
-		<spring-web-version>6.2.0</spring-web-version>
+		<spring-web-version>6.2.1</spring-web-version>
 		
 		<jackson-version>2.18.2</jackson-version>
 		


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.2.2 to 4.3.0 in /client-netstandard](https://github.com/javiertuya/samples-openapi/pull/408)
- [Bump NUnit from 4.2.2 to 4.3.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/407)
- [Bump mikepenz/action-junit-report from 5.1.0 to 5.2.0](https://github.com/javiertuya/samples-openapi/pull/406)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.24.2 to 2.24.3](https://github.com/javiertuya/samples-openapi/pull/405)
- [Bump spring-web-version from 6.2.0 to 6.2.1](https://github.com/javiertuya/samples-openapi/pull/404)