### PR TITLE
Combined dependency updates (2025-01-11)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.4.3
+        uses: actions/upload-artifact@v4.5.0
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     

--- a/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
+++ b/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.0" />
+    <PackageReference Include="NUnit" Version="4.3.2" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.12</version>
+			<version>1.5.15</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.0</version>
+		<version>3.4.1</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump actions/upload-artifact from 4.4.3 to 4.5.0](https://github.com/javiertuya/samples-openapi/pull/414)
- [Bump NUnit from 4.3.0 to 4.3.2 in /client-netstandard](https://github.com/javiertuya/samples-openapi/pull/413)
- [Bump NUnit from 4.3.0 to 4.3.2 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/412)
- [Bump ch.qos.logback:logback-classic from 1.5.12 to 1.5.15](https://github.com/javiertuya/samples-openapi/pull/411)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.0 to 3.4.1](https://github.com/javiertuya/samples-openapi/pull/410)