### PR TITLE
Combined dependency updates (2025-03-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.6.0
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v5.3.0
+        uses: mikepenz/action-junit-report@v5.4.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.4.1</httpclient-version>
+		<httpclient-version>5.4.2</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.18.3</jackson-version>
 		
-		<jackson-databind-version>2.18.2</jackson-databind-version>
+		<jackson-databind-version>2.18.3</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.18.2</jackson-version>
+		<jackson-version>2.18.3</jackson-version>
 		
 		<jackson-databind-version>2.18.2</jackson-databind-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.16</version>
+			<version>2.0.17</version>
 			<scope>compile</scope>
 		</dependency>
 		<!-- instead of logback (default in spring) uses the apache log4j binding -->

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.3.2" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
   </ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     
-    <PackageReference Include="Polly" Version="8.5.1" />
+    <PackageReference Include="Polly" Version="8.5.2" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
+++ b/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
+++ b/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.3.2" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
   </ItemGroup>

--- a/client-netstandard/client-netstandard/client-netstandard.csproj
+++ b/client-netstandard/client-netstandard/client-netstandard.csproj
@@ -14,7 +14,7 @@
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     
-    <PackageReference Include="Polly" Version="8.5.1" />
+    <PackageReference Include="Polly" Version="8.5.2" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.16</version>
+			<version>1.5.17</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.15</swagger-annotations-version>
 		
-		<spring-web-version>6.2.2</spring-web-version>
+		<spring-web-version>6.2.3</spring-web-version>
 		
 		<jackson-version>2.18.2</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.2.3</spring-web-version>
 		
-		<jackson-version>2.18.2</jackson-version>
+		<jackson-version>2.18.3</jackson-version>
 		
 		<jackson-databind-version>2.18.2</jackson-databind-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.18.3</jackson-version>
 		
-		<jackson-databind-version>2.18.2</jackson-databind-version>
+		<jackson-databind-version>2.18.3</jackson-databind-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.16</version>
+			<version>2.0.17</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.2</version>
+		<version>3.4.3</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Microsoft.NET.Test.Sdk from 17.12.0 to 17.13.0 in /client-netstandard](https://github.com/javiertuya/samples-openapi/pull/441)
- [Bump Polly and System.ComponentModel.Annotations in /client-netstandard](https://github.com/javiertuya/samples-openapi/pull/440)
- [Bump NUnit3TestAdapter from 4.6.0 to 5.0.0 in /client-netstandard](https://github.com/javiertuya/samples-openapi/pull/439)
- [Bump NUnit3TestAdapter from 4.6.0 to 5.0.0 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/438)
- [Bump Polly from 8.5.1 to 8.5.2 in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/437)
- [Bump Microsoft.NET.Test.Sdk and Newtonsoft.Json in /client-netcore](https://github.com/javiertuya/samples-openapi/pull/436)
- [Bump actions/upload-artifact from 4.6.0 to 4.6.1](https://github.com/javiertuya/samples-openapi/pull/435)
- [Bump mikepenz/action-junit-report from 5.3.0 to 5.4.0](https://github.com/javiertuya/samples-openapi/pull/434)
- [Bump ch.qos.logback:logback-classic from 1.5.16 to 1.5.17](https://github.com/javiertuya/samples-openapi/pull/433)
- [Bump org.slf4j:slf4j-api from 2.0.16 to 2.0.17](https://github.com/javiertuya/samples-openapi/pull/432)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.1 to 5.4.2](https://github.com/javiertuya/samples-openapi/pull/430)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.2 to 3.4.3](https://github.com/javiertuya/samples-openapi/pull/429)
- [Bump spring-web-version from 6.2.2 to 6.2.3](https://github.com/javiertuya/samples-openapi/pull/428)
- [Bump jackson-version from 2.18.2 to 2.18.3](https://github.com/javiertuya/samples-openapi/pull/427)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.18.2 to 2.18.3](https://github.com/javiertuya/samples-openapi/pull/426)