### PR TITLE
Combined dependency updates (2025-04-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v4.6.1
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v5.4.0
+        uses: mikepenz/action-junit-report@v5.5.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.4.2</httpclient-version>
+		<httpclient-version>5.4.3</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.17</version>
+			<version>1.5.18</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.15</swagger-annotations-version>
 		
-		<spring-web-version>6.2.3</spring-web-version>
+		<spring-web-version>6.2.5</spring-web-version>
 		
 		<jackson-version>2.18.3</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.3</version>
+		<version>3.4.4</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.2 to 5.4.3](https://github.com/javiertuya/samples-openapi/pull/448)
- [Bump ch.qos.logback:logback-classic from 1.5.17 to 1.5.18](https://github.com/javiertuya/samples-openapi/pull/447)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.3 to 3.4.4](https://github.com/javiertuya/samples-openapi/pull/446)
- [Bump spring-web-version from 6.2.3 to 6.2.5](https://github.com/javiertuya/samples-openapi/pull/445)
- [Bump actions/upload-artifact from 4.6.1 to 4.6.2](https://github.com/javiertuya/samples-openapi/pull/444)
- [Bump mikepenz/action-junit-report from 5.4.0 to 5.5.1](https://github.com/javiertuya/samples-openapi/pull/443)