### PR TITLE
Combined dependency updates (2025-05-03)

### DIFF
--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -121,7 +121,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.12.0</version>
+				<version>7.13.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.12.0</version>
+				<version>7.13.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netstandard/pom.xml
+++ b/client-netstandard/pom.xml
@@ -13,7 +13,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.12.0</version>
+				<version>7.13.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -119,7 +119,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.12.0</version>
+				<version>7.13.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -100,7 +100,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.12.0</version>
+				<version>7.13.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.12.0 to 7.13.0](https://github.com/javiertuya/samples-openapi/pull/455)
- [Bump com.fasterxml.jackson.core:jackson-databind from 2.18.3 to 2.19.0](https://github.com/javiertuya/samples-openapi/pull/454)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.4 to 3.4.5](https://github.com/javiertuya/samples-openapi/pull/453)
- [Bump spring-web-version from 6.2.5 to 6.2.6](https://github.com/javiertuya/samples-openapi/pull/452)
- [Bump jackson-version from 2.18.3 to 2.19.0](https://github.com/javiertuya/samples-openapi/pull/451)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.3 to 5.4.4](https://github.com/javiertuya/samples-openapi/pull/450)