### PR TITLE
Combined dependency updates (2025-06-07)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v5.5.1
+        uses: mikepenz/action-junit-report@v5.6.0
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.4.4</httpclient-version>
+		<httpclient-version>5.5</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -15,7 +15,7 @@
 		<maven.compiler.target>17</maven.compiler.target>
 
 		<!--openapi client dependencies: spring resttemplate+jackson -->
-		<swagger-annotations-version>1.6.15</swagger-annotations-version>
+		<swagger-annotations-version>1.6.16</swagger-annotations-version>
 		
 		<spring-web-version>6.2.7</spring-web-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.15</swagger-annotations-version>
 		
-		<spring-web-version>6.2.6</spring-web-version>
+		<spring-web-version>6.2.7</spring-web-version>
 		
 		<jackson-version>2.19.0</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.4.5</version>
+		<version>3.5.0</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump org.springframework:spring-context from 6.2.6 to 6.2.7 in /client-resttemplate](https://github.com/javiertuya/samples-openapi/pull/462)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.4.5 to 3.5.0](https://github.com/javiertuya/samples-openapi/pull/461)
- [Bump io.swagger:swagger-annotations from 1.6.15 to 1.6.16](https://github.com/javiertuya/samples-openapi/pull/460)
- [Bump spring-web-version from 6.2.6 to 6.2.7](https://github.com/javiertuya/samples-openapi/pull/459)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.4.4 to 5.5](https://github.com/javiertuya/samples-openapi/pull/458)
- [Bump mikepenz/action-junit-report from 5.5.1 to 5.6.0](https://github.com/javiertuya/samples-openapi/pull/457)