### PR TITLE
Combined dependency updates (2025-08-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v5.6.1
+        uses: mikepenz/action-junit-report@v5.6.2
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.19.1</jackson-version>
+		<jackson-version>2.19.2</jackson-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.25.0</version>
+		    <version>2.25.1</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     
-    <PackageReference Include="Polly" Version="8.5.2" />
+    <PackageReference Include="Polly" Version="8.6.2" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netstandard/client-netstandard/client-netstandard.csproj
+++ b/client-netstandard/client-netstandard/client-netstandard.csproj
@@ -14,7 +14,7 @@
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     
-    <PackageReference Include="Polly" Version="8.6.1" />
+    <PackageReference Include="Polly" Version="8.6.2" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.16</swagger-annotations-version>
 		
-		<spring-web-version>6.2.8</spring-web-version>
+		<spring-web-version>6.2.9</spring-web-version>
 		
 		<jackson-version>2.19.2</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.2.8</spring-web-version>
 		
-		<jackson-version>2.19.1</jackson-version>
+		<jackson-version>2.19.2</jackson-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.3</version>
+		<version>3.5.4</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Polly from 8.6.1 to 8.6.2](https://github.com/javiertuya/samples-openapi/pull/479)
- [Bump Microsoft.NET.Test.Sdk and Polly](https://github.com/javiertuya/samples-openapi/pull/478)
- [Bump mikepenz/action-junit-report from 5.6.1 to 5.6.2](https://github.com/javiertuya/samples-openapi/pull/477)
- [Bump com.fasterxml.jackson:jackson-bom from 2.19.1 to 2.19.2](https://github.com/javiertuya/samples-openapi/pull/476)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.5.3 to 3.5.4](https://github.com/javiertuya/samples-openapi/pull/475)
- [Bump spring-web-version from 6.2.8 to 6.2.9](https://github.com/javiertuya/samples-openapi/pull/474)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.25.0 to 2.25.1](https://github.com/javiertuya/samples-openapi/pull/473)