### PR TITLE
Combined dependency updates (2025-09-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v4
       - name: Select Java Version
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.19.2</jackson-version>
+		<jackson-version>2.20.0</jackson-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.14.0</version>
+				<version>7.15.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -23,7 +23,7 @@
 		
 		<jackson-version>2.20.0</jackson-version>
 		
-		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+		<jackson-databind-nullable-version>0.2.7</jackson-databind-nullable-version>
 		
 		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 	</properties>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
     

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.14.0</version>
+				<version>7.15.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
+++ b/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.3.2" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>

--- a/client-netstandard/client-netstandard/client-netstandard.csproj
+++ b/client-netstandard/client-netstandard/client-netstandard.csproj
@@ -14,7 +14,7 @@
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     
-    <PackageReference Include="Polly" Version="8.6.2" />
+    <PackageReference Include="Polly" Version="8.6.3" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netstandard/pom.xml
+++ b/client-netstandard/pom.xml
@@ -13,7 +13,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.14.0</version>
+				<version>7.15.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>6.2.9</spring-web-version>
 		
-		<jackson-version>2.19.2</jackson-version>
+		<jackson-version>2.20.0</jackson-version>
 		
 		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -124,7 +124,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.14.0</version>
+				<version>7.15.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.16</swagger-annotations-version>
 		
-		<spring-web-version>6.2.9</spring-web-version>
+		<spring-web-version>6.2.10</spring-web-version>
 		
 		<jackson-version>2.20.0</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -21,7 +21,7 @@
 		
 		<jackson-version>2.20.0</jackson-version>
 		
-		<jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>
+		<jackson-databind-nullable-version>0.2.7</jackson-databind-nullable-version>
 		
 		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 	</properties>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.4</version>
+		<version>3.5.5</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -65,7 +65,7 @@
 		<dependency>
 			<groupId>org.openapitools</groupId>
 			<artifactId>jackson-databind-nullable</artifactId>
-			<version>0.2.6</version>
+			<version>0.2.7</version>
 		</dependency>
 		<!-- Bean Validation API support -->
 		<dependency>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -102,7 +102,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.14.0</version>
+				<version>7.15.0</version>
 				<executions>
 					<execution>
 						<goals>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson:jackson-bom from 2.19.2 to 2.20.0](https://github.com/javiertuya/samples-openapi/pull/490)
- [Bump org.openapitools:jackson-databind-nullable from 0.2.6 to 0.2.7](https://github.com/javiertuya/samples-openapi/pull/489)
- [Bump spring-web-version from 6.2.9 to 6.2.10](https://github.com/javiertuya/samples-openapi/pull/488)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.5.4 to 3.5.5](https://github.com/javiertuya/samples-openapi/pull/487)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.14.0 to 7.15.0](https://github.com/javiertuya/samples-openapi/pull/486)
- [Bump Polly from 8.6.2 to 8.6.3](https://github.com/javiertuya/samples-openapi/pull/485)
- [Bump actions/setup-java from 4 to 5](https://github.com/javiertuya/samples-openapi/pull/484)
- [Bump NUnit3TestAdapter from 5.0.0 to 5.1.0](https://github.com/javiertuya/samples-openapi/pull/483)
- [Bump actions/checkout from 4 to 5](https://github.com/javiertuya/samples-openapi/pull/482)
- [Bump NUnit from 4.3.2 to 4.4.0](https://github.com/javiertuya/samples-openapi/pull/481)