### PR TITLE
Combined dependency updates (2025-10-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
         run: mvn test -pl client-resttemplate,client-httpclient -Dmaven.test.failure.ignore=false -U --no-transfer-progress
 
       - name: Netcore Client - Prepare environment
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
             dotnet-version: '8.0.x'
 

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.25.1</version>
+		    <version>2.25.2</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.5</httpclient-version>
+		<httpclient-version>5.5.1</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.15.0</version>
+				<version>7.16.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="4.4.0" />
     
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
   </ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="2.0.1" />
     
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="112.1.0" />
     
-    <PackageReference Include="Polly" Version="8.6.2" />
+    <PackageReference Include="Polly" Version="8.6.4" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.15.0</version>
+				<version>7.16.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
+++ b/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.4.0" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     

--- a/client-netstandard/pom.xml
+++ b/client-netstandard/pom.xml
@@ -13,7 +13,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.15.0</version>
+				<version>7.16.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.18</version>
+			<version>1.5.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.16</swagger-annotations-version>
 		
-		<spring-web-version>6.2.10</spring-web-version>
+		<spring-web-version>6.2.11</spring-web-version>
 		
 		<jackson-version>2.20.0</jackson-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -124,7 +124,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.15.0</version>
+				<version>7.16.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -102,7 +102,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.15.0</version>
+				<version>7.16.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.5.5</version>
+		<version>3.5.6</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.3.2 to 4.4.0](https://github.com/javiertuya/samples-openapi/pull/502)
- [Bump Polly from 8.6.2 to 8.6.4](https://github.com/javiertuya/samples-openapi/pull/501)
- [Bump NUnit3TestAdapter from 5.0.0 to 5.1.0](https://github.com/javiertuya/samples-openapi/pull/500)
- [Bump Newtonsoft.Json from 13.0.3 to 13.0.4](https://github.com/javiertuya/samples-openapi/pull/499)
- [Bump ch.qos.logback:logback-classic from 1.5.18 to 1.5.19](https://github.com/javiertuya/samples-openapi/pull/498)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.25.1 to 2.25.2](https://github.com/javiertuya/samples-openapi/pull/497)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.5 to 5.5.1](https://github.com/javiertuya/samples-openapi/pull/496)
- [Bump org.springframework.boot:spring-boot-starter-parent from 3.5.5 to 3.5.6](https://github.com/javiertuya/samples-openapi/pull/495)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.15.0 to 7.16.0](https://github.com/javiertuya/samples-openapi/pull/494)
- [Bump spring-web-version from 6.2.10 to 6.2.11](https://github.com/javiertuya/samples-openapi/pull/493)
- [Bump actions/setup-dotnet from 4 to 5](https://github.com/javiertuya/samples-openapi/pull/492)