### PR TITLE
Combined dependency updates (2026-05-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
 
       - if: always()
         name: Publish test report artifacts
-        uses: actions/upload-artifact@v7.0.0
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: test-reports
           path: ./**/target/surefire-reports/

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.6</httpclient-version>
+		<httpclient-version>5.6.1</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.21.0</version>
+				<version>7.22.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -21,7 +21,7 @@
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		
-		<jackson-version>2.21.2</jackson-version>
+		<jackson-version>2.21.3</jackson-version>
 		
 		<jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
 		

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.21.0</version>
+				<version>7.22.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netstandard/pom.xml
+++ b/client-netstandard/pom.xml
@@ -13,7 +13,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.21.0</version>
+				<version>7.22.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -124,7 +124,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.21.0</version>
+				<version>7.22.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -19,7 +19,7 @@
 		
 		<spring-web-version>7.0.6</spring-web-version>
 		
-		<jackson-version>2.21.2</jackson-version>
+		<jackson-version>2.21.3</jackson-version>
 		
 		<jackson-databind-nullable-version>0.2.10</jackson-databind-nullable-version>
 		

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.16</swagger-annotations-version>
 		
-		<spring-web-version>7.0.6</spring-web-version>
+		<spring-web-version>7.0.7</spring-web-version>
 		
 		<jackson-version>2.21.2</jackson-version>
 		

--- a/server-spring/Dockerfile
+++ b/server-spring/Dockerfile
@@ -1,6 +1,6 @@
 #Test api docs at localhost:8080
 #updated by dependabot
-FROM eclipse-temurin:17-jre-alpine@sha256:984703da8353d0a33eb04944b56665e84c6271e5d4f8a679e73cb5bd2b846301
+FROM eclipse-temurin:17-jre-alpine@sha256:88c0002860cda56384d5ed3b2da4d0d9a2b44dc2ee4dc02344be985bd8b524bc
 EXPOSE 8080
 #RUN useradd -u 8877 server
 #USER server

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -96,7 +96,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.21.0</version>
+				<version>7.22.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.5</version>
+		<version>4.0.6</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Microsoft.NET.Test.Sdk from 18.3.0 to 18.5.1](https://github.com/javiertuya/samples-openapi/pull/578)
- [Bump eclipse-temurin from `984703d` to `88c0002` in /server-spring](https://github.com/javiertuya/samples-openapi/pull/577)
- [Bump spring-web-version from 7.0.6 to 7.0.7](https://github.com/javiertuya/samples-openapi/pull/576)
- [Bump com.fasterxml.jackson:jackson-bom from 2.21.2 to 2.21.3](https://github.com/javiertuya/samples-openapi/pull/575)
- [Bump org.springframework.boot:spring-boot-starter-parent from 4.0.5 to 4.0.6](https://github.com/javiertuya/samples-openapi/pull/574)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.6 to 5.6.1](https://github.com/javiertuya/samples-openapi/pull/573)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.21.0 to 7.22.0](https://github.com/javiertuya/samples-openapi/pull/572)
- [Bump actions/upload-artifact from 7.0.0 to 7.0.1](https://github.com/javiertuya/samples-openapi/pull/571)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.6 to 5.6.1 in /client-httpclient](https://github.com/javiertuya/samples-openapi/pull/570)