### PR TITLE
Combined dependency updates (2026-06-02)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.0
+        uses: mikepenz/action-junit-report@v6.4.1
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -108,7 +108,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.17</version>
+			<version>2.0.18</version>
 			<scope>compile</scope>
 		</dependency>
 		<!-- instead of logback (default in spring) uses the apache log4j binding -->

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>6.0.3</version>
+			<version>6.1.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.25.4</version>
+		    <version>2.26.0</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.5.1" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -107,7 +107,7 @@
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.17</version>
+			<version>2.0.18</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>6.0.3</version>
+			<version>6.1.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.32</version>
+			<version>1.5.34</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump NUnit from 4.5.1 to 4.6.1](https://github.com/javiertuya/samples-openapi/pull/587)
- [Bump Microsoft.NET.Test.Sdk from 18.5.1 to 18.6.0](https://github.com/javiertuya/samples-openapi/pull/586)
- [Bump org.slf4j:slf4j-api from 2.0.17 to 2.0.18](https://github.com/javiertuya/samples-openapi/pull/585)
- [Bump org.junit.jupiter:junit-jupiter-engine from 6.0.3 to 6.1.0](https://github.com/javiertuya/samples-openapi/pull/584)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.25.4 to 2.26.0](https://github.com/javiertuya/samples-openapi/pull/583)
- [Bump ch.qos.logback:logback-classic from 1.5.32 to 1.5.34](https://github.com/javiertuya/samples-openapi/pull/581)
- [Bump mikepenz/action-junit-report from 6.4.0 to 6.4.1](https://github.com/javiertuya/samples-openapi/pull/580)