### PR TITLE
Combined dependency updates (2026-07-04)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GitHub repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Select Java Version
         uses: actions/setup-java@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Publish test reports
         if: always()
-        uses: mikepenz/action-junit-report@v6.4.1
+        uses: mikepenz/action-junit-report@v6.4.2
         with:
           check_name: test-report
           report_paths: '**/target/surefire-reports/TEST-*.xml'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -126,7 +126,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.22.0</version>
+				<version>7.23.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>6.1.0</version>
+			<version>6.1.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.6.1</httpclient-version>
+		<httpclient-version>5.6.2</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -22,7 +22,7 @@
     
     <PackageReference Include="RestSharp" Version="114.0.0" />
     
-    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="Polly" Version="8.7.0" />
     
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
   </ItemGroup>

--- a/client-netcore/pom.xml
+++ b/client-netcore/pom.xml
@@ -21,7 +21,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.22.0</version>
+				<version>7.23.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-netstandard/pom.xml
+++ b/client-netstandard/pom.xml
@@ -13,7 +13,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.22.0</version>
+				<version>7.23.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -124,7 +124,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.22.0</version>
+				<version>7.23.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.34</version>
+			<version>1.5.37</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>6.1.0</version>
+			<version>6.1.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies: spring resttemplate+jackson -->
 		<swagger-annotations-version>1.6.16</swagger-annotations-version>
 		
-		<spring-web-version>7.0.7</spring-web-version>
+		<spring-web-version>7.0.8</spring-web-version>
 		
 		<jackson-version>2.21.3</jackson-version>
 		

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -96,7 +96,7 @@
 			<plugin>
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
-				<version>7.22.0</version>
+				<version>7.23.0</version>
 				<executions>
 					<execution>
 						<goals>

--- a/server-spring/pom.xml
+++ b/server-spring/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.6</version>
+		<version>4.1.0</version>
 		<!--relative path empty as this is a submodule, but spring starter needs to be the parent-->
 		<relativePath />
 	</parent>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump Polly from 8.6.6 to 8.7.0](https://github.com/javiertuya/samples-openapi/pull/598)
- [Bump Microsoft.NET.Test.Sdk from 18.6.0 to 18.7.0](https://github.com/javiertuya/samples-openapi/pull/597)
- [Bump ch.qos.logback:logback-classic from 1.5.34 to 1.5.37](https://github.com/javiertuya/samples-openapi/pull/596)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.6.1 to 5.6.2](https://github.com/javiertuya/samples-openapi/pull/595)
- [Bump org.openapitools:openapi-generator-maven-plugin from 7.22.0 to 7.23.0](https://github.com/javiertuya/samples-openapi/pull/594)
- [Bump org.springframework.boot:spring-boot-starter-parent from 4.0.6 to 4.1.0](https://github.com/javiertuya/samples-openapi/pull/593)
- [Bump org.junit.jupiter:junit-jupiter-engine from 6.1.0 to 6.1.1](https://github.com/javiertuya/samples-openapi/pull/592)
- [Bump spring-web-version from 7.0.7 to 7.0.8](https://github.com/javiertuya/samples-openapi/pull/591)
- [Bump mikepenz/action-junit-report from 6.4.1 to 6.4.2](https://github.com/javiertuya/samples-openapi/pull/590)
- [Bump actions/checkout from 6 to 7](https://github.com/javiertuya/samples-openapi/pull/589)