### PR TITLE
Migrate .NET client test projects to net10.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Netcore Client - Prepare environment
         uses: actions/setup-dotnet@v5
         with:
-            dotnet-version: '8.0.x'
+            dotnet-version: '10.0.x'
 
       #Generates api with maven for unified generation
       #Run build before test to fail if complie errors

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>client_netcore</RootNamespace>
 
     <IsPackable>false</IsPackable>

--- a/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
+++ b/client-netstandard/client-netstandard-test/client-netstandard-test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>client_netstandard_test</RootNamespace>
 
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
﻿## .NET 8 ? .NET 10 migration

Updates the .NET client test projects to target `net10.0`:

- `.github/workflows/test.yml`: `setup-dotnet` `8.0.x` ? `10.0.x`
- `client-netcore/client-netcore/client-netcore.csproj`: `net8.0` ? `net10.0`
- `client-netstandard/client-netstandard-test/client-netstandard-test.csproj`: `net8.0` ? `net10.0`

`client-netstandard/client-netstandard.csproj` (`netstandard2.0`) is **left unchanged** and intentionally kept for broad library compatibility.

?? Generated with [Claude Code](https://claude.com/claude-code)
