### PR TITLE
ci: avoid duplicate workflow run on pull requests from the local repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    #avoids duplicate execution of pr from local repo, but allows pr from forked repos and dependabot
+    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
     steps:
       - name: Checkout GitHub repo
         uses: actions/checkout@v7


### PR DESCRIPTION
Adds the conditional that prevents the test workflow from running twice on pull requests created from a branch of this repo.

- PR from a local branch: only the `push` event runs, the `pull_request` one is skipped.
- PR from a fork or from dependabot: the `pull_request` event runs.

Only the test jobs are affected.
