### PR TITLE
Combined dependency updates (2026-08-03)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         run: mvn test -pl client-resttemplate,client-httpclient -Dmaven.test.failure.ignore=false -U --no-transfer-progress
 
       - name: Netcore Client - Prepare environment
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@v6
         with:
             dotnet-version: '10.0.x'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout GitHub repo
         uses: actions/checkout@v7
       - name: Select Java Version
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v5.6.0
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -29,7 +29,7 @@
 		-->
 		<jackson-version>3.1.4</jackson-version>
 
-		<jackson-annotations-version>2.21</jackson-annotations-version>
+		<jackson-annotations-version>2.22</jackson-annotations-version>
 
 		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 	</properties>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>6.1.1</version>
+			<version>6.1.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -115,7 +115,7 @@
 		<dependency>
 		    <groupId>org.apache.logging.log4j</groupId>
 		    <artifactId>log4j-slf4j2-impl</artifactId>
-		    <version>2.26.0</version>
+		    <version>2.26.1</version>
 		    <scope>test</scope>
 		</dependency>
 

--- a/client-httpclient/pom.xml
+++ b/client-httpclient/pom.xml
@@ -17,7 +17,7 @@
 		<!--openapi client dependencies spring apache httpclient + jackson -->
 		<swagger-annotations-version>1.6.9</swagger-annotations-version>
 		
-		<httpclient-version>5.6.2</httpclient-version>
+		<httpclient-version>5.6.3</httpclient-version>
 		
 		<spring-web-version>5.3.19</spring-web-version>
 		

--- a/client-netcore/client-netcore/client-netcore.csproj
+++ b/client-netcore/client-netcore/client-netcore.csproj
@@ -12,7 +12,7 @@
     
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -113,7 +113,7 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.37</version>
+			<version>1.6.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -27,7 +27,7 @@
 		-->
 		<jackson-version>3.1.4</jackson-version>
 
-		<jackson-annotations-version>2.21</jackson-annotations-version>
+		<jackson-annotations-version>2.22</jackson-annotations-version>
 
 		<jakarta-annotation-version>3.0.0</jakarta-annotation-version>
 	</properties>

--- a/client-resttemplate/pom.xml
+++ b/client-resttemplate/pom.xml
@@ -101,7 +101,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
-			<version>6.1.1</version>
+			<version>6.1.2</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Dependabot updates combined by [DashGit](https://javiertuya.github.io/dashgit). Includes:
- [Bump com.fasterxml.jackson.core:jackson-annotations from 2.21 to 2.22](https://github.com/javiertuya/samples-openapi/pull/614)
- [Bump Microsoft.NET.Test.Sdk from 18.7.0 to 18.8.1](https://github.com/javiertuya/samples-openapi/pull/612)
- [Bump org.apache.logging.log4j:log4j-slf4j2-impl from 2.26.0 to 2.26.1](https://github.com/javiertuya/samples-openapi/pull/609)
- [Bump org.apache.httpcomponents.client5:httpclient5 from 5.6.2 to 5.6.3](https://github.com/javiertuya/samples-openapi/pull/608)
- [Bump ch.qos.logback:logback-classic from 1.5.37 to 1.6.1](https://github.com/javiertuya/samples-openapi/pull/607)
- [Bump actions/setup-dotnet from 5 to 6](https://github.com/javiertuya/samples-openapi/pull/606)
- [Bump actions/setup-java from 5 to 5.6.0](https://github.com/javiertuya/samples-openapi/pull/604)
- [Bump org.junit.jupiter:junit-jupiter-engine from 6.1.1 to 6.1.2](https://github.com/javiertuya/samples-openapi/pull/603)